### PR TITLE
不変なサブツリーがあればキャッシュしてリビルドごとに再利用するリファクタリング

### DIFF
--- a/encryption_sns/lib/process_view.dart
+++ b/encryption_sns/lib/process_view.dart
@@ -14,7 +14,7 @@ class ProcessView extends StatefulWidget {
 }
 
 class _ProcessViewState extends State<ProcessView> {
-
+  final appBar = AppBar(title: Text('処理画面'));
   final textFieldController = TextEditingController();
   FocusNode focusNode = FocusNode();
 
@@ -32,7 +32,7 @@ class _ProcessViewState extends State<ProcessView> {
         focusNode.unfocus();
       },
       child: Scaffold(
-        appBar: AppBar(title: Text('処理画面')),
+        appBar: appBar,
         body: SingleChildScrollView(
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.center,

--- a/encryption_sns/lib/process_view.dart
+++ b/encryption_sns/lib/process_view.dart
@@ -16,7 +16,7 @@ class ProcessView extends StatefulWidget {
 class _ProcessViewState extends State<ProcessView> {
   final appBar = AppBar(title: Text('処理画面'));
   final textFieldController = TextEditingController();
-  FocusNode focusNode = FocusNode();
+  final FocusNode focusNode = FocusNode();
 
   @override
   // widgetの破棄時にコントローラも破棄する


### PR DESCRIPTION
- appBarをキャッシュ

そんなに大規模ではなったのでキャッシュする値があまりなかった

## issue
#13 