### PR TITLE
異なったバスワードで処理を行うとresultTextWidgetでエラーが起こるバグの修正

### DIFF
--- a/encryption_sns/lib/Bloc/application_bloc.dart
+++ b/encryption_sns/lib/Bloc/application_bloc.dart
@@ -4,7 +4,7 @@ import 'package:encrypt/encrypt.dart';
 class ApplicationBloc {
   final _encryptionController = StreamController<void>();
   final _decryptionController = StreamController<void>();
-  final _showingTextController = StreamController<String>();
+  final _showingTextController = StreamController<String>.broadcast();
 
   final _processInputTextFieldController = StreamController<String>();
 


### PR DESCRIPTION
# 概要
表題

#  issue
#21 